### PR TITLE
TzParser: test gmTime pointer

### DIFF
--- a/Src/TzParser.cpp
+++ b/Src/TzParser.cpp
@@ -430,6 +430,7 @@ TzTransitionList parseTimeZone(const char* tzName)
 		const ttentry& entry = ttEntryList[i];
 		const ttinfo& info   = ttInfoList[entry.indexToLocalTime];
 		struct tm* gmTime    = gmtime(&entry.time);
+		if (NULL==gmTime) continue;
 		
 		TzTransition trans;
 		trans.time        = entry.time;


### PR DESCRIPTION
When gmtime fails, a NULL pointer is returned. This
will cause a crash.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>