### PR TITLE
luna-sysservice: Add missing outbound permissions

### DIFF
--- a/files/sysbus/com.webos.service.systemservice.service.role.json.in
+++ b/files/sysbus/com.webos.service.systemservice.service.role.json.in
@@ -10,7 +10,9 @@
 				"com.webos.service.settingsservice",
 				"com.webos.service.telephony",
 				"com.webos.service.alarm",
-				"com.webos.service.applicationManager"
+				"com.webos.service.applicationManager",
+				"com.webos.service.activitymanager.client",
+				"com.webos.monitor"
 			]
 		}
 	]


### PR DESCRIPTION
Fixes:

Jun 15 15:20:40 qemux86-64 ls-hubd[267]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.monitor","SRC_APP_ID":"com.webos.service.systemservice","EXE":"/usr/sbin/LunaSysService","PID":391} "com.webos.service.systemservice" does not have sufficient outbound permissions to communicate with "com.webos.monitor" (cmdline: /usr/sbin/LunaSysService)

Jun 15 14:57:51 qemux86-64 ls-hubd[267]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.webos.service.activitymanager.client","SRC_APP_ID":"com.webos.service.systemservice","EXE":"/usr/sbin/LunaSysService","PID":391} "com.webos.service.systemservice" does not have sufficient outbound permissions to communicate with "com.webos.service.activitymanager.client" (cmdline: /usr/sbin/LunaSysService)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>